### PR TITLE
Solved an access violation on views opening

### DIFF
--- a/Kide/Source/KIDE.BorderPanelControllerDesignerFrameUnit.pas
+++ b/Kide/Source/KIDE.BorderPanelControllerDesignerFrameUnit.pas
@@ -62,7 +62,7 @@ type
       const ARegion: string): string;
     function GetRegionControllerName(
       const ARegion: string): string;
-    function FindBorderPanelControllerClass(const ANode: TEFNode): TExtTabPanel;
+    function FindBorderPanelControllerClass(const ANode: TEFNode): TExtTabPanelClass;
     procedure UpdateControllerGUI(const ARegion: string;
       const AButton: TSpeedButton; const ATabSheet: TTabSheet);
     procedure UpdateViewGUI(const ARegion: string;
@@ -118,7 +118,7 @@ end;
 
 procedure TBorderPanelControllerDesignerFrame.Init(const ANode: TEFTree);
 var
-  LBorderPanelControllerClass: TExtTabPanel;
+  LBorderPanelControllerClass: TExtTabPanelClass;
 (*
   procedure InitController(const ANodeName: string; const ATabSheet: TTabSheet);
   var
@@ -156,13 +156,13 @@ begin
 end;
 
 function TBorderPanelControllerDesignerFrame.FindBorderPanelControllerClass(
-  const ANode: TEFNode): TExtTabPanel;
+  const ANode: TEFNode): TExtTabPanelClass;
 var
   LControllerClass: TClass;
 begin
   LControllerClass := GetControllerClass(ANode);
   if Assigned(LControllerClass) then
-    Result := TExtTabPanel(LControllerClass)
+    Result := TExtTabPanelClass(LControllerClass)
   else
     Result := nil;
 end;
@@ -170,7 +170,7 @@ end;
 function TBorderPanelControllerDesignerFrame.GetRegionViewName(
   const ARegion: string): string;
 var
-  LBorderPanelControllerClass: TExtTabPanel;
+  LBorderPanelControllerClass: TExtTabPanelClass;
 begin
   LBorderPanelControllerClass := FindBorderPanelControllerClass(TEFNode(EditNode));
   if Assigned(LBorderPanelControllerClass) then
@@ -182,7 +182,7 @@ end;
 function TBorderPanelControllerDesignerFrame.GetRegionControllerName(
   const ARegion: string): string;
 var
-  LBorderPanelControllerClass: TExtTabPanel;
+  LBorderPanelControllerClass: TExtTabPanelClass;
 begin
   LBorderPanelControllerClass := FindBorderPanelControllerClass(EditNode as TEFNode);
   if Assigned(LBorderPanelControllerClass) then

--- a/Source/Ext/Ext.Base.pas
+++ b/Source/Ext/Ext.Base.pas
@@ -700,6 +700,7 @@ type
   // Procedural types for events TExtTabPanel
   TExtTabPanelOnTabChange = procedure(ATabPanel: TExtTabPanel; ANewTab: TExtComponent) of object;
 
+  TExtTabPanelClass = class of TExtPanel;
   TExtTabPanel = class(TExtPanel)
   private
     FOnTabChange: TExtTabPanelOnTabChange;


### PR DESCRIPTION
Durante la migrazione del codice di 5 mesi fa sembra che un type cast sia passato da classe a oggetto generando un access violation nel momento in cui si tenta di aprire una vista